### PR TITLE
added darwin and windows define-foreign-library options

### DIFF
--- a/src/main.lisp
+++ b/src/main.lisp
@@ -1,10 +1,14 @@
 (in-package :cl-tidy)
 
 (define-foreign-library libtidy
+  (:darwin (:or "libtidy.dylib"
+                "/usr/local/lib/libtidy.dylib"))
   (:unix (:or "libtidy.so"
-	      "/git/cl-tidy/lib/libtidy.so"
-	      "/usr/local/lib/libtidy.so"
-	      "/git/suave/cl-tidy/tidylib/lib/libtidy.so")))
+              "/git/cl-tidy/lib/libtidy.so"
+              "/usr/local/lib/libtidy.so"
+              "/git/suave/cl-tidy/tidylib/lib/libtidy.so"))
+  (:windows "libTidy.dll")
+  (t (:default "libtidy")))
 
 (use-foreign-library libtidy)
 


### PR DESCRIPTION
When loading the libtidy library it doesn't work on mac os after installing with homebrew. The only thing left, I added what to do on darwin and windows sytems